### PR TITLE
FP80 - 修正後台商品頁面過寬版面 & 活動文章顯示

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -127,7 +127,11 @@ function Shop() {
 
   const [user, setUser] = useState()
   useEffect(() => {
-    if (!getTokenFromLocalStorage() || isTokenExpired(getTokenFromLocalStorage())) return false
+    if (
+      !getTokenFromLocalStorage() ||
+      isTokenExpired(getTokenFromLocalStorage())
+    )
+      return false
     try {
       const _info = jwt_decode(getTokenFromLocalStorage())
       if (_info.hasOwnProperty('id')) return setUser(_info)

--- a/src/components/admin/productManage/FormStyle.js
+++ b/src/components/admin/productManage/FormStyle.js
@@ -1,15 +1,27 @@
 import styled from 'styled-components'
-import { ADMIN_COLOR, COLOR, FONT_SIZE } from '../../../constants/style'
+import {
+  ADMIN_COLOR,
+  COLOR,
+  FONT_SIZE,
+  ADMIN_MEDIA_QUERY
+} from '../../../constants/style'
 import { EditBtn, LogoutBtn, SaveBtn } from '../../../components/Button'
 
 const FormWrapper = styled.div`
   min-height: 850px;
   height: 850px;
   transition: 1.5s;
-  width: 90%;
   margin: 30px auto;
   border: 1px solid ${ADMIN_COLOR.border_grey};
+  width: 70vw;
+  ${ADMIN_MEDIA_QUERY.md} {
+    max-width: 1480px;
+  }
+  ${ADMIN_MEDIA_QUERY.lg} {
+    max-width: 1480px;
+  }
 `
+
 const Form = styled.form`
   padding: 20px 0px 50px 0px;
   height: 100%;

--- a/src/components/admin/productManage/Table.js
+++ b/src/components/admin/productManage/Table.js
@@ -155,7 +155,8 @@ function TableItem({ product }) {
           count={productQuantity}
         />
       </ProductCell>
-      <ProductCell>{article}</ProductCell>
+      {article !== 'null' && <ProductCell>{article}</ProductCell>}
+      {article === 'null' && <ProductCell>無</ProductCell>}
       <ProductCell>
         <ButtonContainer onClick={handleOnStatusClick} id={id}>
           <StatusButton status={productStatus} id={id} />


### PR DESCRIPTION
本次完成部分 :
1. 將後台商品新增與編輯頁面過寬問題修正
2. 後台商品管理介面中活動文章資訊顯示修正，從 'null' 改為 '無'